### PR TITLE
added functions for namespace and virtual interface management

### DIFF
--- a/fog05sdk/plugin.go
+++ b/fog05sdk/plugin.go
@@ -969,6 +969,30 @@ func (ag *Agent) GetFDUInfo(nodeid string, fduid string, instanceid string) (*FD
 	}
 }
 
+// GetFDUDescriptor returns the descriptor for the given FDU ID
+func (ag *Agent) GetFDUDescriptor(fduid string) (*FDU, error) {
+	r, err := ag.CallAgentFunction("get_fdu_info", map[string]interface{}{"fdu_uuid": fduid})
+	if err != nil {
+		return nil, err
+	}
+
+	x := *r
+	switch bb := x.(type) {
+	case map[string]interface{}:
+		sv := x.(map[string]interface{})
+		jsv, err := json.Marshal(sv)
+		if err != nil {
+			return nil, err
+		}
+		ssv := FDU{}
+		json.Unmarshal(jsv, &ssv)
+		return &ssv, nil
+	default:
+		er := FError{"Unexpected type: " + bb.(string), nil}
+		return nil, &er
+	}
+}
+
 // GetNetworkInfo given a network id returns the VirtualNetwork object associated
 func (ag *Agent) GetNetworkInfo(netid string) (*VirtualNetwork, error) {
 	r, err := ag.CallAgentFunction("get_network_info", map[string]interface{}{"uuid": netid})

--- a/fog05sdk/plugin.go
+++ b/fog05sdk/plugin.go
@@ -741,20 +741,20 @@ func (nm *NM) CreateNetworkNamespace() (string, error) {
 }
 
 // DeleteNetworkNamespace deletes the given network namespace, and returns its name
-func (nm *NM) DeleteNetworkNamespace(netns string) (*map[string]interface{}, error) {
+func (nm *NM) DeleteNetworkNamespace(netns string) (string, error) {
 	r, err := nm.CallNMPluginFunction("delete_network_namespace", map[string]interface{}{"nsname": netns})
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	x := *r
 	switch bb := x.(type) {
 	case map[string]interface{}:
-		sv := x.(map[string]interface{})
-		return &sv, nil
+		sv := x.(string)
+		return sv, nil
 	default:
 		er := FError{"Unexpected type: " + bb.(string), nil}
-		return nil, &er
+		return "", &er
 	}
 }
 

--- a/fog05sdk/plugin.go
+++ b/fog05sdk/plugin.go
@@ -723,6 +723,131 @@ func (nm *NM) RemoveNodePort(cpid string) error {
 	return nm.connector.Local.Desired.AddNodePort(nm.node, nm.uuid, cpid, *cpd)
 }
 
+// CreateNetworkNamespace creates a new network namespace, and returns its name
+func (nm *NM) CreateNetworkNamespace() (string, error) {
+	r, err := nm.CallNMPluginFunction("create_network_namespace", map[string]interface{}{})
+	if err != nil {
+		return "", err
+	}
+
+	x := *r
+	switch bb := x.(type) {
+	case string:
+		return x.(string), nil
+	default:
+		er := FError{"Unexpected type: " + bb.(string), nil}
+		return "", &er
+	}
+}
+
+// DeleteNetworkNamespace deletes the given network namespace, and returns its name
+func (nm *NM) DeleteNetworkNamespace(netns string) (*map[string]interface{}, error) {
+	r, err := nm.CallNMPluginFunction("delete_network_namespace", map[string]interface{}{"nsname": netns})
+	if err != nil {
+		return nil, err
+	}
+
+	x := *r
+	switch bb := x.(type) {
+	case map[string]interface{}:
+		sv := x.(map[string]interface{})
+		return &sv, nil
+	default:
+		er := FError{"Unexpected type: " + bb.(string), nil}
+		return nil, &er
+	}
+}
+
+// CreateVirtualInterfaceInNamespace creates a veth pair in the given network namespace, with the given name for the internal interface
+func (nm *NM) CreateVirtualInterfaceInNamespace(intfName string, netns string) (*map[string]interface{}, error) {
+	r, err := nm.CallNMPluginFunction("create_virtual_interface_in_namespace", map[string]interface{}{"internal_name": intfName, "nsname": netns})
+	if err != nil {
+		return nil, err
+	}
+
+	x := *r
+	switch bb := x.(type) {
+	case map[string]interface{}:
+		sv := x.(map[string]interface{})
+		return &sv, nil
+	default:
+		er := FError{"Unexpected type: " + bb.(string), nil}
+		return nil, &er
+	}
+}
+
+// DeleteVirtualInterfaceFromNamespace deletes the given interface from the the given network namespace
+func (nm *NM) DeleteVirtualInterfaceFromNamespace(intfName string, netns string) (*map[string]interface{}, error) {
+	r, err := nm.CallNMPluginFunction("delete_virtual_interface_from_namespace", map[string]interface{}{"internal_name": intfName, "nsname": netns})
+	if err != nil {
+		return nil, err
+	}
+
+	x := *r
+	switch bb := x.(type) {
+	case map[string]interface{}:
+		sv := x.(map[string]interface{})
+		return &sv, nil
+	default:
+		er := FError{"Unexpected type: " + bb.(string), nil}
+		return nil, &er
+	}
+}
+
+// AssignAddressToInterfaceInNamespace assigns the given address to the given interface in the the given network namespace, address are in the form AAA.AAA.AAA.AAA/NM
+func (nm *NM) AssignAddressToInterfaceInNamespace(intfName string, netns string, address string) (*map[string]interface{}, error) {
+	r, err := nm.CallNMPluginFunction("assign_address_to_interface_in_namespace", map[string]interface{}{"intf_name": intfName, "nsname": netns, "address": address})
+	if err != nil {
+		return nil, err
+	}
+
+	x := *r
+	switch bb := x.(type) {
+	case map[string]interface{}:
+		sv := x.(map[string]interface{})
+		return &sv, nil
+	default:
+		er := FError{"Unexpected type: " + bb.(string), nil}
+		return nil, &er
+	}
+}
+
+// GetAddressOfInterfaceInNamespace retrieves the address to the given interface in the the given network namespace
+func (nm *NM) GetAddressOfInterfaceInNamespace(intfName string, netns string) (*map[string]interface{}, error) {
+	r, err := nm.CallNMPluginFunction("get_address_of_interface_in_namespace", map[string]interface{}{"intf_name": intfName, "nsname": netns})
+	if err != nil {
+		return nil, err
+	}
+
+	x := *r
+	switch bb := x.(type) {
+	case map[string]interface{}:
+		sv := x.(map[string]interface{})
+		return &sv, nil
+	default:
+		er := FError{"Unexpected type: " + bb.(string), nil}
+		return nil, &er
+	}
+}
+
+// RemoveAddressFromInterfaceInNamespace removes the address from the given interface in the the given network namespace
+func (nm *NM) RemoveAddressFromInterfaceInNamespace(intfName string, netns string) (*map[string]interface{}, error) {
+	r, err := nm.CallNMPluginFunction("remove_address_from_interface_in_namespace", map[string]interface{}{"intf_name": intfName, "nsname": netns})
+	if err != nil {
+		return nil, err
+	}
+
+	x := *r
+	switch bb := x.(type) {
+	case map[string]interface{}:
+		sv := x.(map[string]interface{})
+		return &sv, nil
+	default:
+		er := FError{"Unexpected type: " + bb.(string), nil}
+		return nil, &er
+	}
+}
+
 // Agent is the object to interect with the Agent
 type Agent struct {
 	connector *YaksConnector

--- a/fog05sdk/plugin.go
+++ b/fog05sdk/plugin.go
@@ -831,7 +831,7 @@ func (nm *NM) AssignAddressToInterfaceInNamespace(intfName string, netns string,
 }
 
 // AssignMACAddressToInterfaceInNamespace assigns the given address to the given interface in the the given network namespace, address are in the form AA:BB:CC:DD:EE:FF
-func (nm *NM) AssignMACAddressToInterfaceInNamespace(intfName string, netns string, address string) (*InterfaceInfo, error) {
+func (nm *NM) AssignMACAddressToInterfaceInNamespace(intfName string, netns string, address string) (*NamespaceInfo, error) {
 	r, err := nm.CallNMPluginFunction("assign_mac_address_to_interface_in_namespace", map[string]interface{}{"intf_name": intfName, "nsname": netns, "address": address})
 	if err != nil {
 		return nil, err
@@ -845,7 +845,7 @@ func (nm *NM) AssignMACAddressToInterfaceInNamespace(intfName string, netns stri
 		if err != nil {
 			return nil, err
 		}
-		ssv := InterfaceInfo{}
+		ssv := NamespaceInfo{}
 		json.Unmarshal(jsv, &ssv)
 		return &ssv, nil
 	default:

--- a/fog05sdk/plugin.go
+++ b/fog05sdk/plugin.go
@@ -812,6 +812,24 @@ func (nm *NM) AssignAddressToInterfaceInNamespace(intfName string, netns string,
 	}
 }
 
+// AssignMACAddressToInterfaceInNamespace assigns the given address to the given interface in the the given network namespace, address are in the form AA:BB:CC:DD:EE:FF
+func (nm *NM) AssignMACAddressToInterfaceInNamespace(intfName string, netns string, address string) (*map[string]interface{}, error) {
+	r, err := nm.CallNMPluginFunction("assign_mac_address_to_interface_in_namespace", map[string]interface{}{"intf_name": intfName, "nsname": netns, "address": address})
+	if err != nil {
+		return nil, err
+	}
+
+	x := *r
+	switch bb := x.(type) {
+	case map[string]interface{}:
+		sv := x.(map[string]interface{})
+		return &sv, nil
+	default:
+		er := FError{"Unexpected type: " + bb.(string), nil}
+		return nil, &er
+	}
+}
+
 // GetAddressOfInterfaceInNamespace retrieves the address to the given interface in the the given network namespace
 func (nm *NM) GetAddressOfInterfaceInNamespace(intfName string, netns string) (*map[string]interface{}, error) {
 	r, err := nm.CallNMPluginFunction("get_address_of_interface_in_namespace", map[string]interface{}{"intf_name": intfName, "nsname": netns})

--- a/fog05sdk/plugin.go
+++ b/fog05sdk/plugin.go
@@ -759,7 +759,7 @@ func (nm *NM) DeleteNetworkNamespace(netns string) (*map[string]interface{}, err
 }
 
 // CreateVirtualInterfaceInNamespace creates a veth pair in the given network namespace, with the given name for the internal interface
-func (nm *NM) CreateVirtualInterfaceInNamespace(intfName string, netns string) (*map[string]interface{}, error) {
+func (nm *NM) CreateVirtualInterfaceInNamespace(intfName string, netns string) (*NamespaceInfo, error) {
 	r, err := nm.CallNMPluginFunction("create_virtual_interface_in_namespace", map[string]interface{}{"internal_name": intfName, "nsname": netns})
 	if err != nil {
 		return nil, err
@@ -769,7 +769,13 @@ func (nm *NM) CreateVirtualInterfaceInNamespace(intfName string, netns string) (
 	switch bb := x.(type) {
 	case map[string]interface{}:
 		sv := x.(map[string]interface{})
-		return &sv, nil
+		jsv, err := json.Marshal(sv)
+		if err != nil {
+			return nil, err
+		}
+		ssv := NamespaceInfo{}
+		json.Unmarshal(jsv, &ssv)
+		return &ssv, nil
 	default:
 		er := FError{"Unexpected type: " + bb.(string), nil}
 		return nil, &er
@@ -777,7 +783,7 @@ func (nm *NM) CreateVirtualInterfaceInNamespace(intfName string, netns string) (
 }
 
 // DeleteVirtualInterfaceFromNamespace deletes the given interface from the the given network namespace
-func (nm *NM) DeleteVirtualInterfaceFromNamespace(intfName string, netns string) (*map[string]interface{}, error) {
+func (nm *NM) DeleteVirtualInterfaceFromNamespace(intfName string, netns string) (*NamespaceInfo, error) {
 	r, err := nm.CallNMPluginFunction("delete_virtual_interface_from_namespace", map[string]interface{}{"internal_name": intfName, "nsname": netns})
 	if err != nil {
 		return nil, err
@@ -787,7 +793,13 @@ func (nm *NM) DeleteVirtualInterfaceFromNamespace(intfName string, netns string)
 	switch bb := x.(type) {
 	case map[string]interface{}:
 		sv := x.(map[string]interface{})
-		return &sv, nil
+		jsv, err := json.Marshal(sv)
+		if err != nil {
+			return nil, err
+		}
+		ssv := NamespaceInfo{}
+		json.Unmarshal(jsv, &ssv)
+		return &ssv, nil
 	default:
 		er := FError{"Unexpected type: " + bb.(string), nil}
 		return nil, &er
@@ -795,7 +807,7 @@ func (nm *NM) DeleteVirtualInterfaceFromNamespace(intfName string, netns string)
 }
 
 // AssignAddressToInterfaceInNamespace assigns the given address to the given interface in the the given network namespace, address are in the form AAA.AAA.AAA.AAA/NM
-func (nm *NM) AssignAddressToInterfaceInNamespace(intfName string, netns string, address string) (*map[string]interface{}, error) {
+func (nm *NM) AssignAddressToInterfaceInNamespace(intfName string, netns string, address string) (*NamespaceInfo, error) {
 	r, err := nm.CallNMPluginFunction("assign_address_to_interface_in_namespace", map[string]interface{}{"intf_name": intfName, "nsname": netns, "address": address})
 	if err != nil {
 		return nil, err
@@ -805,7 +817,13 @@ func (nm *NM) AssignAddressToInterfaceInNamespace(intfName string, netns string,
 	switch bb := x.(type) {
 	case map[string]interface{}:
 		sv := x.(map[string]interface{})
-		return &sv, nil
+		jsv, err := json.Marshal(sv)
+		if err != nil {
+			return nil, err
+		}
+		ssv := NamespaceInfo{}
+		json.Unmarshal(jsv, &ssv)
+		return &ssv, nil
 	default:
 		er := FError{"Unexpected type: " + bb.(string), nil}
 		return nil, &er
@@ -813,7 +831,7 @@ func (nm *NM) AssignAddressToInterfaceInNamespace(intfName string, netns string,
 }
 
 // AssignMACAddressToInterfaceInNamespace assigns the given address to the given interface in the the given network namespace, address are in the form AA:BB:CC:DD:EE:FF
-func (nm *NM) AssignMACAddressToInterfaceInNamespace(intfName string, netns string, address string) (*map[string]interface{}, error) {
+func (nm *NM) AssignMACAddressToInterfaceInNamespace(intfName string, netns string, address string) (*InterfaceInfo, error) {
 	r, err := nm.CallNMPluginFunction("assign_mac_address_to_interface_in_namespace", map[string]interface{}{"intf_name": intfName, "nsname": netns, "address": address})
 	if err != nil {
 		return nil, err
@@ -823,7 +841,13 @@ func (nm *NM) AssignMACAddressToInterfaceInNamespace(intfName string, netns stri
 	switch bb := x.(type) {
 	case map[string]interface{}:
 		sv := x.(map[string]interface{})
-		return &sv, nil
+		jsv, err := json.Marshal(sv)
+		if err != nil {
+			return nil, err
+		}
+		ssv := InterfaceInfo{}
+		json.Unmarshal(jsv, &ssv)
+		return &ssv, nil
 	default:
 		er := FError{"Unexpected type: " + bb.(string), nil}
 		return nil, &er
@@ -831,7 +855,7 @@ func (nm *NM) AssignMACAddressToInterfaceInNamespace(intfName string, netns stri
 }
 
 // GetAddressOfInterfaceInNamespace retrieves the address to the given interface in the the given network namespace
-func (nm *NM) GetAddressOfInterfaceInNamespace(intfName string, netns string) (*map[string]interface{}, error) {
+func (nm *NM) GetAddressOfInterfaceInNamespace(intfName string, netns string) (*InterfaceInfo, error) {
 	r, err := nm.CallNMPluginFunction("get_address_of_interface_in_namespace", map[string]interface{}{"intf_name": intfName, "nsname": netns})
 	if err != nil {
 		return nil, err
@@ -841,7 +865,13 @@ func (nm *NM) GetAddressOfInterfaceInNamespace(intfName string, netns string) (*
 	switch bb := x.(type) {
 	case map[string]interface{}:
 		sv := x.(map[string]interface{})
-		return &sv, nil
+		jsv, err := json.Marshal(sv)
+		if err != nil {
+			return nil, err
+		}
+		ssv := InterfaceInfo{}
+		json.Unmarshal(jsv, &ssv)
+		return &ssv, nil
 	default:
 		er := FError{"Unexpected type: " + bb.(string), nil}
 		return nil, &er
@@ -849,7 +879,7 @@ func (nm *NM) GetAddressOfInterfaceInNamespace(intfName string, netns string) (*
 }
 
 // RemoveAddressFromInterfaceInNamespace removes the address from the given interface in the the given network namespace
-func (nm *NM) RemoveAddressFromInterfaceInNamespace(intfName string, netns string) (*map[string]interface{}, error) {
+func (nm *NM) RemoveAddressFromInterfaceInNamespace(intfName string, netns string) (*NamespaceInfo, error) {
 	r, err := nm.CallNMPluginFunction("remove_address_from_interface_in_namespace", map[string]interface{}{"intf_name": intfName, "nsname": netns})
 	if err != nil {
 		return nil, err
@@ -859,7 +889,13 @@ func (nm *NM) RemoveAddressFromInterfaceInNamespace(intfName string, netns strin
 	switch bb := x.(type) {
 	case map[string]interface{}:
 		sv := x.(map[string]interface{})
-		return &sv, nil
+		jsv, err := json.Marshal(sv)
+		if err != nil {
+			return nil, err
+		}
+		ssv := NamespaceInfo{}
+		json.Unmarshal(jsv, &ssv)
+		return &ssv, nil
 	default:
 		er := FError{"Unexpected type: " + bb.(string), nil}
 		return nil, &er

--- a/fog05sdk/types.go
+++ b/fog05sdk/types.go
@@ -215,14 +215,7 @@ type Plugin struct {
 	Configuration *jsont   `json:"configuration,omitempty"`
 }
 
-// EvalResult represents results of Eval
-type EvalResult struct {
-	Result       *interface{} `json:"result,omitempty"`
-	Error        *int         `json:"error,omitempty"`
-	ErrorMessage *string      `json:"error_msg,omitempty"`
-}
-
-// InterfaceInfo ...
+// InterfaceInfo represents the results of interface managements functions in the network manager plugin
 type InterfaceInfo struct {
 	Name string `json:"name"`
 	IPV4 string `json:"ipv4"`
@@ -230,9 +223,16 @@ type InterfaceInfo struct {
 	MAC  string `json:"mac"`
 }
 
-// NamespaceInfo ...
+// NamespaceInfo represents the results of network namespace managements functions in the network manager plugin
 type NamespaceInfo struct {
 	Namespace string        `json:"namespace"`
 	Internal  InterfaceInfo `json:"internal"`
 	External  InterfaceInfo `json:"external"`
+}
+
+// EvalResult represents results of Eval
+type EvalResult struct {
+	Result       *interface{} `json:"result,omitempty"`
+	Error        *int         `json:"error,omitempty"`
+	ErrorMessage *string      `json:"error_msg,omitempty"`
 }

--- a/fog05sdk/types.go
+++ b/fog05sdk/types.go
@@ -221,3 +221,18 @@ type EvalResult struct {
 	Error        *int         `json:"error,omitempty"`
 	ErrorMessage *string      `json:"error_msg,omitempty"`
 }
+
+// InterfaceInfo ...
+type InterfaceInfo struct {
+	Name string `json:"name"`
+	IPV4 string `json:"ipv4"`
+	IPV6 string `json:"ipv6"`
+	MAC  string `json:"mac"`
+}
+
+// NamespaceInfo ...
+type NamespaceInfo struct {
+	Namespace string        `json:"namespace"`
+	Internal  InterfaceInfo `json:"internal"`
+	External  InterfaceInfo `json:"external"`
+}


### PR DESCRIPTION
Added functions:

-  create_network_namespace
-  delete_network_namespace
-  create_virtual_interface_in_namespace
-  delete_virtual_interface_from_namespace
-  assign_address_to_interface_in_namespace
-  get_address_of_interface_in_namespace
-  remove_address_from_interface_in_namespace
